### PR TITLE
Fixing build directory issue and the scripting bug about filenames

### DIFF
--- a/biovoxxel-figure-tools/pom.xml
+++ b/biovoxxel-figure-tools/pom.xml
@@ -154,7 +154,7 @@ The LUT Channels Tool allows to customize personal favorite LUTs, tests Color de
 	      <groupId>org.apache.maven.plugins</groupId>
 	      <artifactId>maven-jar-plugin</artifactId>
 	     <configuration>
-	        <outputDirectory>D:/BioVoxxel/Fiji/Fiji.app - BVTB 3.0/plugins</outputDirectory>
+	        <outputDirectory>build</outputDirectory>
 	      </configuration>
 	    </plugin>
 	  </plugins>

--- a/biovoxxel-figure-tools/src/main/java/svg/gui/SVGExporter.java
+++ b/biovoxxel-figure-tools/src/main/java/svg/gui/SVGExporter.java
@@ -28,7 +28,7 @@ public class SVGExporter extends DynamicCommand {
 	@Parameter
 	ImagePlus imp;
 
-	@Parameter(label = "File name", initializer = "getImageName", required = true, persist = false)
+	@Parameter(label = "File name", required = true, persist = false)
 	String fileName = "NoName.svg";
 	
 	@Parameter(label = "Target folder", required = true, style = "directory")


### PR DESCRIPTION
This pull request contains 2 fixes:

1. build directory in the pom.xml file was specific to a windows system. To have more general compatibility `build` or `target` are better. (I picked `build`)
To move files after build, `mvn && cp build/<name> /path/to/plugins/directory` (or something similar for Windows) could be a practical solution.
2. Closes #7 (filenames were ignored in macros) From what I have seen the initializer argument of `fileName` @parameter was not really required, since there is a check for file name.
